### PR TITLE
Add project scaffolding CLI and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ The documentation lives in the [`docs/`](docs/) directory and is rendered with M
 `mkdocs-shadcn` theme. Preview changes locally with `uv run mkdocs serve` and publish to GitHub Pages
 via `uv run mkdocs gh-deploy --force`.
 
+## CLI project generator
+
+Create a production-ready Mere service, complete with quickstart wiring, IaC skeletons, and local
+Compose tooling, using the bundled CLI:
+
+```bash
+uv run mere new my-service --git-host github --iac terraform --backbone aws
+```
+
+The generator can target GitHub or GitLab CI, multiple IaC providers (Terraform, OpenTofu, Kubernetes,
+CloudFormation), and backbone clouds (AWS, DigitalOcean, Cloudflare, Google Cloud, Azure). Use
+`--skip-dev-stack` if you do not need the Docker Compose PostgreSQL/Keycloak development environment.
+Run `uv run mere new --help` to inspect the full matrix of options at any time.
+
 ### Database bootstrap
 
 When the app exposes a `Database` and `ORM`, the quickstart helper automatically runs

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -18,6 +18,33 @@ Calling `attach_quickstart` registers routes, configures tenancy metadata, and l
 front-end assets. The helper is idempotent—calling it multiple times inspects the existing state and
 only applies missing pieces.
 
+## Scaffolding a production project
+
+The `mere` CLI can materialise a complete project—including tenancy-aware quickstart wiring,
+infrastructure definitions, and local developer tooling—in a single command:
+
+```bash
+uv run mere new my-service \
+  --git-host github \
+  --iac terraform \
+  --backbone aws
+```
+
+The generator creates:
+
+- `app/` with a ready-to-serve `MereApp` that calls `attach_quickstart` and exposes a `/health` probe.
+- `app/runtime.py` exposing `get_database()`/`get_tenants()` so migrations and test data snapshots work
+  out of the box.
+- CI workflows tailored to GitHub or GitLab with the full `ruff`/`ty`/`pytest` quality bar.
+- IaC skeletons for Terraform/OpenTofu, Kubernetes, or CloudFormation preconfigured for AWS,
+  Google Cloud, Azure, DigitalOcean, or Cloudflare.
+- `ops/docker-compose.yml` to launch PostgreSQL 16 and Keycloak 23 locally, matching the quickstart
+  authentication flows.
+
+Use `--skip-dev-stack` to omit the Docker Compose files if your team relies on an alternative local
+stack, and swap `--iac`/`--backbone`/`--git-host` to match your production environment. Consult
+`uv run mere new --help` whenever you need a refresher on the supported combinations.
+
 ## Authentication flows
 
 - **Acme tenant** – configured for SAML SSO with Okta metadata. Use it to validate SSO login logic.

--- a/src/mere/scaffold.py
+++ b/src/mere/scaffold.py
@@ -1,0 +1,762 @@
+"""Project scaffolding helpers for Mere."""
+
+from __future__ import annotations
+
+from textwrap import dedent
+from typing import Final, Iterable, Literal
+
+from msgspec import Struct
+
+GIT_HOSTS: Final[tuple[str, ...]] = ("github", "gitlab")
+IAC_PROVIDERS: Final[tuple[str, ...]] = ("terraform", "opentofu", "k8s", "cfn")
+BACKBONES: Final[tuple[str, ...]] = ("aws", "digitalocean", "cloudflare", "gcp", "azure")
+
+
+class ProjectOptions(Struct, frozen=True):
+    """Declarative inputs for project scaffolding."""
+
+    name: str
+    git_host: Literal["github", "gitlab"]
+    iac: Literal["terraform", "opentofu", "k8s", "cfn"]
+    backbone: Literal["aws", "digitalocean", "cloudflare", "gcp", "azure"]
+    include_dev_stack: bool = True
+
+
+class ProjectFile(Struct, frozen=True):
+    """Materialised file produced during scaffolding."""
+
+    path: str
+    content: str
+
+
+class ProjectSummary(Struct, frozen=True):
+    """Result of rendering a project template."""
+
+    files: tuple[ProjectFile, ...]
+
+
+def render_project(options: ProjectOptions) -> ProjectSummary:
+    """Render a production-ready Mere project based on ``options``."""
+
+    slug = _normalize_package(options.name)
+    title = _title_case(options.name)
+    files: list[ProjectFile] = []
+
+    files.extend(_core_files(options, slug, title))
+    files.extend(_ci_files(options))
+    files.extend(_iac_files(options, slug))
+
+    if options.include_dev_stack:
+        files.extend(_dev_stack_files())
+
+    return ProjectSummary(files=tuple(files))
+
+
+def _core_files(options: ProjectOptions, slug: str, title: str) -> Iterable[ProjectFile]:
+    env = _env_template()
+    gitignore = _gitignore_template()
+    readme = _readme_template(options, title)
+    pyproject = _pyproject_template(slug)
+    app_module = _app_template()
+    runtime_module = _runtime_template()
+    main_module = _main_module_template()
+    return (
+        ProjectFile(path=".env.example", content=env),
+        ProjectFile(path=".gitignore", content=gitignore),
+        ProjectFile(path="README.md", content=readme),
+        ProjectFile(path="pyproject.toml", content=pyproject),
+        ProjectFile(path="app/__init__.py", content=""),
+        ProjectFile(path="app/application.py", content=app_module),
+        ProjectFile(path="app/runtime.py", content=runtime_module),
+        ProjectFile(path="app/__main__.py", content=main_module),
+    )
+
+
+def _ci_files(options: ProjectOptions) -> Iterable[ProjectFile]:
+    if options.git_host == "github":
+        workflow = _github_ci_template()
+        return (ProjectFile(path=".github/workflows/ci.yml", content=workflow),)
+    workflow = _gitlab_ci_template()
+    return (ProjectFile(path=".gitlab-ci.yml", content=workflow),)
+
+
+def _iac_files(options: ProjectOptions, slug: str) -> Iterable[ProjectFile]:
+    if options.iac in {"terraform", "opentofu"}:
+        return (
+            ProjectFile(path=f"infra/{options.iac}/main.tf", content=_terraform_template(options)),
+            ProjectFile(path=f"infra/{options.iac}/variables.tf", content=_terraform_variables_template()),
+            ProjectFile(path=f"infra/{options.iac}/README.md", content=_terraform_readme_template(options)),
+        )
+    if options.iac == "k8s":
+        return (
+            ProjectFile(path="infra/k8s/namespace.yaml", content=_k8s_namespace_template(slug)),
+            ProjectFile(path="infra/k8s/deployment.yaml", content=_k8s_deployment_template(slug)),
+            ProjectFile(path="infra/k8s/service.yaml", content=_k8s_service_template(slug)),
+            ProjectFile(path="infra/k8s/ingress.yaml", content=_k8s_ingress_template(options, slug)),
+        )
+    return (
+        ProjectFile(path="infra/cfn/template.yaml", content=_cfn_template(options, slug)),
+        ProjectFile(path="infra/cfn/README.md", content=_cfn_readme(options)),
+    )
+
+
+def _dev_stack_files() -> Iterable[ProjectFile]:
+    compose = _compose_template()
+    ops_readme = _ops_readme_template()
+    return (
+        ProjectFile(path="ops/docker-compose.yml", content=compose),
+        ProjectFile(path="ops/README.md", content=ops_readme),
+        ProjectFile(path="ops/migrations/.keep", content=""),
+    )
+
+
+def _env_template() -> str:
+    return dedent(
+        """\
+        MERE_ENV=development
+        MERE_SITE=demo
+        MERE_DOMAIN=local.test
+        MERE_ALLOWED_TENANTS=acme,beta
+        DATABASE_URL=postgresql://mere:mere@localhost:5432/mere
+        SLACK_WEBHOOK_URL=http://localhost:9090/mock-slack
+        """
+    )
+
+
+def _gitignore_template() -> str:
+    return dedent(
+        """\
+        __pycache__/
+        *.py[cod]
+        .env
+        .venv/
+        .mypy_cache/
+        .pytest_cache/
+        .uv/
+        ops/postgres-data/
+        ops/keycloak-data/
+        infra/**/.terraform/
+        infra/**/.terraform.lock.hcl
+        """
+    )
+
+
+def _readme_template(options: ProjectOptions, title: str) -> str:
+    git_label = options.git_host.title()
+    backbone = _backbone_label(options.backbone)
+    if options.iac == "k8s":
+        iac_label = "Kubernetes"
+    else:
+        iac_label = options.iac.upper()
+    return (
+        dedent(
+            f"""\
+        # {title}
+
+        Production-ready Mere deployment scaffolded for {backbone} with {iac_label}.
+
+        ## Stack
+
+        - Git host: {git_label}
+        - Infrastructure as Code: {iac_label}
+        - Backbone provider: {backbone}
+        - Local services: Docker Compose (PostgreSQL 16 + Keycloak 23)
+
+        ## Getting started
+
+        ```bash
+        uv sync
+        cp .env.example .env
+        docker compose -f ops/docker-compose.yml up --detach
+        uv run mere migrate --module app.runtime
+        uv run python -m app
+        ```
+
+        ## Project layout
+
+        - `app/` - ASGI application wiring and route registration.
+        - `infra/` - IaC definitions for the selected backbone.
+        - `ops/` - Local developer tooling (Compose stack, seed data).
+        - CI configuration for the chosen git host.
+
+        This scaffold boots with the Mere quickstart so your local environment matches
+        the production authentication and tenancy flows. Adjust the seed data in
+        `app/runtime.py` before promoting tenants to real customers.
+        """
+        ).strip()
+        + "\n"
+    )
+
+
+def _pyproject_template(package: str) -> str:
+    script = package.replace("_", "-")
+    return dedent(
+        f"""\
+        [project]
+        name = "{package}"
+        version = "0.1.0"
+        description = "Production Mere service"
+        requires-python = ">=3.11"
+        dependencies = [
+            "mere",
+        ]
+
+        [tool.uv]
+        package = false
+
+        [project.scripts]
+        {script} = "app.application:main"
+        """
+    )
+
+
+def _app_template() -> str:
+    return (
+        dedent(
+            """\
+        from __future__ import annotations
+
+        import os
+
+        from mere import AppConfig, MereApp, attach_quickstart
+        from mere.database import DatabaseConfig, PoolConfig
+        from mere.requests import Request
+        from mere.responses import JSONResponse
+        from mere.server import run
+
+
+        def _allowed_tenants() -> tuple[str, ...]:
+            raw = os.getenv("MERE_ALLOWED_TENANTS", "acme,beta")
+            return tuple(sorted({tenant.strip() for tenant in raw.split(",") if tenant.strip()}))
+
+
+        def create_app() -> MereApp:
+            config = AppConfig(
+                site=os.getenv("MERE_SITE", "demo"),
+                domain=os.getenv("MERE_DOMAIN", "local.test"),
+                allowed_tenants=_allowed_tenants(),
+                database=DatabaseConfig(
+                    pool=PoolConfig(dsn=os.getenv("DATABASE_URL", "postgresql://mere:mere@localhost:5432/mere"))
+                ),
+            )
+            app = MereApp(config)
+            attach_quickstart(app)
+
+            @app.get("/health", name="health")
+            async def health(_: Request) -> JSONResponse:
+                return JSONResponse({"status": "ok"})
+
+            return app
+
+
+        def main() -> None:
+            app = create_app()
+            run(app)
+        """
+        ).strip()
+        + "\n"
+    )
+
+
+def _runtime_template() -> str:
+    return (
+        dedent(
+            """\
+        from __future__ import annotations
+
+        import os
+
+        from mere import AppConfig
+        from mere.database import Database, DatabaseConfig, PoolConfig
+        from mere.tenancy import TenantContext, TenantScope
+
+
+        def _parse_tenants() -> tuple[str, ...]:
+            raw = os.getenv("MERE_ALLOWED_TENANTS", "acme,beta")
+            return tuple(sorted({tenant.strip() for tenant in raw.split(",") if tenant.strip()}))
+
+
+        def build_config() -> AppConfig:
+            allowed = _parse_tenants()
+            database_url = os.getenv("DATABASE_URL")
+            database_config: DatabaseConfig | None = None
+            if database_url:
+                database_config = DatabaseConfig(pool=PoolConfig(dsn=database_url))
+            return AppConfig(
+                site=os.getenv("MERE_SITE", "demo"),
+                domain=os.getenv("MERE_DOMAIN", "local.test"),
+                allowed_tenants=allowed,
+                database=database_config,
+            )
+
+
+        def get_database() -> Database:
+            config = build_config()
+            if config.database is None:
+                raise RuntimeError("DATABASE_URL must be configured to run migrations")
+            return Database(config.database)
+
+
+        def get_tenants() -> tuple[TenantContext, ...]:
+            config = build_config()
+            tenants: list[TenantContext] = []
+            for slug in config.allowed_tenants:
+                tenants.append(
+                    TenantContext(
+                        tenant=slug,
+                        site=config.site,
+                        domain=config.domain,
+                        scope=TenantScope.TENANT,
+                    )
+                )
+            return tuple(tenants)
+        """
+        ).strip()
+        + "\n"
+    )
+
+
+def _main_module_template() -> str:
+    return (
+        dedent(
+            """\
+        from .application import main
+
+
+        if __name__ == "__main__":
+            main()
+        """
+        ).strip()
+        + "\n"
+    )
+
+
+def _github_ci_template() -> str:
+    return dedent(
+        """\
+        name: CI
+
+        on:
+          push:
+            branches: [main]
+          pull_request:
+
+        jobs:
+          quality:
+            runs-on: ubuntu-latest
+            steps:
+              - uses: actions/checkout@v4
+              - uses: astral-sh/setup-uv@v2
+              - run: uv sync
+              - run: uv run ruff check
+              - run: uv run ty check
+              - run: uv run pytest
+        """
+    )
+
+
+def _gitlab_ci_template() -> str:
+    return dedent(
+        """\
+        stages:
+          - quality
+
+        quality:
+          stage: quality
+          image: ghcr.io/astral-sh/uv:latest
+          script:
+            - uv sync
+            - uv run ruff check
+            - uv run ty check
+            - uv run pytest
+        """
+    )
+
+
+def _terraform_template(options: ProjectOptions) -> str:
+    provider = _terraform_provider_block(options.backbone)
+    tool = "tofu" if options.iac == "opentofu" else "terraform"
+    body = dedent(
+        f"""\
+        {tool} {{
+          required_version = ">= 1.5.0"
+          required_providers {{
+{provider.required_provider}
+          }}
+        }}
+
+{provider.provider_block}
+
+        module "mere" {{
+          source = "./modules/mere"
+          site   = var.site
+          domain = var.domain
+        }}
+        """
+    )
+    return body.strip() + "\n"
+
+
+def _terraform_variables_template() -> str:
+    return dedent(
+        """\
+        variable "site" {
+          type        = string
+          description = "Mere site identifier"
+        }
+
+        variable "domain" {
+          type        = string
+          description = "Base domain for tenant routing"
+        }
+        """
+    )
+
+
+def _terraform_readme_template(options: ProjectOptions) -> str:
+    tool = "OpenTofu" if options.iac == "opentofu" else "Terraform"
+    provider = _backbone_label(options.backbone)
+    return dedent(
+        f"""\
+        # {tool} deployment
+
+        Apply the Mere infrastructure stack on {provider}:
+
+        ```bash
+        {tool.lower()} init
+        {tool.lower()} apply
+        ```
+
+        Populate `terraform.tfvars` with values for the variables declared in `variables.tf`.
+        """
+    )
+
+
+def _k8s_namespace_template(package: str) -> str:
+    return dedent(
+        f"""\
+        apiVersion: v1
+        kind: Namespace
+        metadata:
+          name: {package}
+        """
+    )
+
+
+def _k8s_deployment_template(package: str) -> str:
+    return dedent(
+        f"""\
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: {package}-web
+          namespace: {package}
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              app: {package}-web
+          template:
+            metadata:
+              labels:
+                app: {package}-web
+            spec:
+              containers:
+                - name: mere
+                  image: ghcr.io/your-org/{package}:latest
+                  env:
+                    - name: MERE_ENV
+                      value: production
+                    - name: DATABASE_URL
+                      valueFrom:
+                        secretKeyRef:
+                          name: {package}-database
+                          key: url
+                  ports:
+                    - containerPort: 8000
+        """
+    )
+
+
+def _k8s_service_template(package: str) -> str:
+    return dedent(
+        f"""\
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: {package}-web
+          namespace: {package}
+        spec:
+          selector:
+            app: {package}-web
+          ports:
+            - port: 80
+              targetPort: 8000
+        """
+    )
+
+
+def _k8s_ingress_template(options: ProjectOptions, package: str) -> str:
+    backbone = _backbone_label(options.backbone)
+    return dedent(
+        f"""\
+        apiVersion: networking.k8s.io/v1
+        kind: Ingress
+        metadata:
+          name: {package}-ingress
+          namespace: {package}
+          annotations:
+            meta.mere.dev/backbone: "{backbone}"
+        spec:
+          rules:
+            - host: api.{package}.example.com
+              http:
+                paths:
+                  - path: /
+                    pathType: Prefix
+                    backend:
+                      service:
+                        name: {package}-web
+                        port:
+                          number: 80
+        """
+    )
+
+
+def _cfn_template(options: ProjectOptions, package: str) -> str:
+    provider = _backbone_label(options.backbone)
+    return dedent(
+        f"""\
+        AWSTemplateFormatVersion: '2010-09-09'
+        Description: Mere service for {provider}
+        Resources:
+          MereService:
+            Type: AWS::ECS::Service
+            Properties:
+              Cluster: !Ref MereCluster
+              DesiredCount: 2
+              LaunchType: FARGATE
+              ServiceName: {package}-service
+              TaskDefinition: !Ref MereTaskDefinition
+          MereCluster:
+            Type: AWS::ECS::Cluster
+          MereTaskDefinition:
+            Type: AWS::ECS::TaskDefinition
+            Properties:
+              Cpu: '512'
+              Memory: '1024'
+              NetworkMode: awsvpc
+              RequiresCompatibilities:
+                - FARGATE
+              ContainerDefinitions:
+                - Name: mere
+                  Image: public.ecr.aws/your-org/{package}:latest
+                  PortMappings:
+                    - ContainerPort: 8000
+                  Environment:
+                    - Name: MERE_ENV
+                      Value: production
+                    - Name: DATABASE_URL
+                      Value: {{resolve:secretsmanager:{package}/database:SecretString:url}}
+        """
+    )
+
+
+def _cfn_readme(options: ProjectOptions) -> str:
+    provider = _backbone_label(options.backbone)
+    return dedent(
+        f"""\
+        # CloudFormation deployment
+
+        Deploy the stack on {provider}:
+
+        ```bash
+        aws cloudformation deploy \\
+          --template-file template.yaml \\
+          --stack-name mere-stack \\
+          --capabilities CAPABILITY_NAMED_IAM
+        ```
+
+        Parameterise the template before deploying to production environments.
+        """
+    )
+
+
+def _compose_template() -> str:
+    return dedent(
+        """\
+        version: '3.9'
+
+        services:
+          postgres:
+            image: postgres:16-alpine
+            ports:
+              - "5432:5432"
+            environment:
+              POSTGRES_DB: mere
+              POSTGRES_USER: mere
+              POSTGRES_PASSWORD: mere
+            volumes:
+              - ./postgres-data:/var/lib/postgresql/data
+
+          keycloak:
+            image: quay.io/keycloak/keycloak:23.0
+            command:
+              - start-dev
+              - --http-port=8081
+            environment:
+              KC_DB: postgres
+              KC_DB_URL: jdbc:postgresql://postgres:5432/mere
+              KC_DB_USERNAME: mere
+              KC_DB_PASSWORD: mere
+              KEYCLOAK_ADMIN: admin
+              KEYCLOAK_ADMIN_PASSWORD: admin
+            ports:
+              - "8081:8080"
+            depends_on:
+              - postgres
+            volumes:
+              - ./keycloak-data:/opt/keycloak/data
+        """
+    )
+
+
+def _ops_readme_template() -> str:
+    return dedent(
+        """\
+        # Developer operations
+
+        ```bash
+        # Start PostgreSQL and Keycloak
+        docker compose -f ops/docker-compose.yml up --detach
+
+        # Tear them down
+        docker compose -f ops/docker-compose.yml down --volumes
+        ```
+        """
+    )
+
+
+class _TerraformProvider(Struct, frozen=True):
+    required_provider: str
+    provider_block: str
+
+
+def _terraform_provider_block(backbone: str) -> _TerraformProvider:
+    if backbone == "aws":
+        return _TerraformProvider(
+            required_provider=dedent(
+                """\
+                    aws = {
+                      source  = \"hashicorp/aws\"
+                      version = \"~> 5.0\"
+                    }
+                """
+            ).strip(),
+            provider_block=dedent(
+                """\
+                provider \"aws\" {
+                  region = var.region
+                }
+                """
+            ).strip(),
+        )
+    if backbone == "gcp":
+        return _TerraformProvider(
+            required_provider=dedent(
+                """\
+                    google = {
+                      source  = \"hashicorp/google\"
+                      version = \"~> 5.0\"
+                    }
+                """
+            ).strip(),
+            provider_block=dedent(
+                """\
+                provider \"google\" {
+                  project = var.project
+                  region  = var.region
+                }
+                """
+            ).strip(),
+        )
+    if backbone == "azure":
+        return _TerraformProvider(
+            required_provider=dedent(
+                """\
+                    azurerm = {
+                      source  = \"hashicorp/azurerm\"
+                      version = \"~> 3.0\"
+                    }
+                """
+            ).strip(),
+            provider_block=dedent(
+                """\
+                provider \"azurerm\" {
+                  features {}
+                }
+                """
+            ).strip(),
+        )
+    if backbone == "digitalocean":
+        return _TerraformProvider(
+            required_provider=dedent(
+                """\
+                    digitalocean = {
+                      source  = \"digitalocean/digitalocean\"
+                      version = \"~> 2.0\"
+                    }
+                """
+            ).strip(),
+            provider_block='provider "digitalocean" {}',
+        )
+    return _TerraformProvider(
+        required_provider=dedent(
+            """\
+                cloudflare = {
+                  source  = \"cloudflare/cloudflare\"
+                  version = \"~> 4.0\"
+                }
+            """
+        ).strip(),
+        provider_block=dedent(
+            """\
+            provider \"cloudflare\" {
+              api_token = var.api_token
+            }
+            """
+        ).strip(),
+    )
+
+
+def _backbone_label(backbone: str) -> str:
+    mapping = {
+        "aws": "AWS",
+        "digitalocean": "DigitalOcean",
+        "cloudflare": "Cloudflare",
+        "gcp": "Google Cloud Platform",
+        "azure": "Microsoft Azure",
+    }
+    return mapping.get(backbone, backbone.title())
+
+
+def _normalize_package(name: str) -> str:
+    cleaned = [ch if ch.isalnum() else "_" for ch in name.lower()]
+    slug = "".join(cleaned).strip("_")
+    return slug or "mere_service"
+
+
+def _title_case(name: str) -> str:
+    parts = [part for part in name.replace("-", " ").replace("_", " ").split() if part]
+    return " ".join(part.capitalize() for part in parts) or "Mere Service"
+
+
+__all__ = [
+    "BACKBONES",
+    "GIT_HOSTS",
+    "IAC_PROVIDERS",
+    "ProjectFile",
+    "ProjectOptions",
+    "ProjectSummary",
+    "render_project",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import pathlib
 from types import SimpleNamespace
 from typing import Sequence
 
 import pytest
 
 import mere.cli as cli
+from mere.scaffold import ProjectFile, ProjectOptions, ProjectSummary
 
 
 def test_quality_runs_all_steps(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -34,3 +36,91 @@ def test_quality_stops_on_first_failure(monkeypatch: pytest.MonkeyPatch) -> None
 
     assert cli.quality() == 2
     assert calls == [tuple(cli.QUALITY_COMMANDS[0]), tuple(cli.QUALITY_COMMANDS[1])]
+
+
+def test_new_project_scaffolds_files(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "demo-service"
+    result = cli.main(
+        [
+            "new",
+            str(target),
+            "--git-host",
+            "github",
+            "--iac",
+            "terraform",
+            "--backbone",
+            "aws",
+        ]
+    )
+    assert result == 0
+
+    readme = (target / "README.md").read_text(encoding="utf-8")
+    assert "AWS" in readme
+
+    app_module = (target / "app/application.py").read_text(encoding="utf-8")
+    assert "attach_quickstart" in app_module
+
+    workflow = (target / ".github/workflows/ci.yml").read_text(encoding="utf-8")
+    assert "uv run pytest" in workflow
+
+    compose = (target / "ops/docker-compose.yml").read_text(encoding="utf-8")
+    assert "postgres:16-alpine" in compose
+
+    terraform = (target / "infra/terraform/main.tf").read_text(encoding="utf-8")
+    assert 'provider "aws"' in terraform
+
+
+def test_new_project_gitlab_k8s_without_dev_stack(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "demo"
+    result = cli.main(
+        [
+            "new",
+            str(target),
+            "--git-host",
+            "gitlab",
+            "--iac",
+            "k8s",
+            "--backbone",
+            "gcp",
+            "--skip-dev-stack",
+        ]
+    )
+    assert result == 0
+
+    assert (target / ".gitlab-ci.yml").exists()
+    assert not (target / "ops/docker-compose.yml").exists()
+
+    deployment = (target / "infra/k8s/deployment.yaml").read_text(encoding="utf-8")
+    assert "namespace: demo" in deployment
+
+
+def test_new_project_rejects_non_empty_target(tmp_path: pathlib.Path) -> None:
+    target = tmp_path / "demo"
+    target.mkdir()
+    (target / "README.md").write_text("existing", encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        cli.main(["new", str(target)])
+
+
+def test_new_project_rejects_file_target(tmp_path: pathlib.Path) -> None:
+    path = tmp_path / "demo"
+    path.write_text("file", encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        cli.main(["new", str(path)])
+
+
+def test_new_project_rejects_overwrite(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    target = tmp_path / "demo"
+    target.mkdir()
+
+    def fake_render_project(options: ProjectOptions) -> ProjectSummary:
+        existing = target / ".env.example"
+        existing.write_text("preexisting", encoding="utf-8")
+        return ProjectSummary(files=(ProjectFile(path=".env.example", content="data"),))
+
+    monkeypatch.setattr(cli, "render_project", fake_render_project)
+
+    with pytest.raises(SystemExit):
+        cli.main(["new", str(target)])

--- a/tests/test_scaffold.py
+++ b/tests/test_scaffold.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import pytest
+
+from mere import scaffold
+
+
+def _options(
+    *,
+    name: str = "Demo Service",
+    git_host: str = "github",
+    iac: str = "terraform",
+    backbone: str = "aws",
+    include_dev_stack: bool = True,
+) -> scaffold.ProjectOptions:
+    return scaffold.ProjectOptions(
+        name=name,
+        git_host=git_host,  # type: ignore[arg-type]
+        iac=iac,  # type: ignore[arg-type]
+        backbone=backbone,  # type: ignore[arg-type]
+        include_dev_stack=include_dev_stack,
+    )
+
+
+def test_render_project_generates_expected_core_files() -> None:
+    summary = scaffold.render_project(_options())
+    paths = {file.path for file in summary.files}
+    assert ".env.example" in paths
+    assert "app/application.py" in paths
+    assert "infra/terraform/main.tf" in paths
+    assert "ops/docker-compose.yml" in paths
+
+    pyproject = next(file for file in summary.files if file.path == "pyproject.toml")
+    assert 'name = "demo_service"' in pyproject.content
+
+
+def test_render_project_without_dev_stack() -> None:
+    summary = scaffold.render_project(_options(include_dev_stack=False))
+    paths = {file.path for file in summary.files}
+    assert "ops/docker-compose.yml" not in paths
+
+
+@pytest.mark.parametrize(
+    "iac, expected",
+    [
+        ("terraform", 'module "mere"'),
+        ("opentofu", "tofu"),
+        ("k8s", "apiVersion: apps/v1"),
+        ("cfn", "AWS::ECS::Service"),
+    ],
+)
+def test_render_project_various_iac(iac: str, expected: str) -> None:
+    summary = scaffold.render_project(_options(iac=iac))
+    content = "\n".join(file.content for file in summary.files if file.path.startswith("infra/"))
+    assert expected in content
+
+
+def test_render_project_respects_backbone_labels() -> None:
+    summary = scaffold.render_project(_options(backbone="gcp"))
+    readme = next(file for file in summary.files if file.path == "README.md")
+    assert "Google Cloud Platform" in readme.content
+
+
+def test_terraform_provider_blocks_cover_all_backbones() -> None:
+    providers = {
+        "aws": scaffold._terraform_provider_block("aws"),
+        "gcp": scaffold._terraform_provider_block("gcp"),
+        "azure": scaffold._terraform_provider_block("azure"),
+        "digitalocean": scaffold._terraform_provider_block("digitalocean"),
+        "cloudflare": scaffold._terraform_provider_block("cloudflare"),
+    }
+    assert "hashicorp/aws" in providers["aws"].required_provider
+    assert 'provider "google"' in providers["gcp"].provider_block
+    assert "features {}" in providers["azure"].provider_block
+    assert providers["digitalocean"].provider_block == 'provider "digitalocean" {}'
+    assert "api_token" in providers["cloudflare"].provider_block
+
+
+def test_cfn_templates_use_backbone_label() -> None:
+    template = scaffold._cfn_template(_options(backbone="digitalocean"), "demo")
+    readme = scaffold._cfn_readme(_options(backbone="digitalocean"))
+    assert "DigitalOcean" in template
+    assert "DigitalOcean" in readme
+
+
+def test_compose_and_ops_templates() -> None:
+    compose = scaffold._compose_template()
+    ops = scaffold._ops_readme_template()
+    assert "postgres" in compose
+    assert "docker compose" in ops


### PR DESCRIPTION
## Summary
- add `mere new` CLI command for scaffolding projects and hook it into docs
- implement scaffolding templates covering multiple IaC providers and clouds
- add tests covering the CLI branches and template helpers

## Testing
- `uv run ruff format`
- `uv run ruff check`
- `uv run ty check`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d92711f070832e8fca34fc45501435