### PR TITLE
Fix Granian server loader for direct MereApp instances

### DIFF
--- a/src/mere/server.py
+++ b/src/mere/server.py
@@ -7,6 +7,30 @@ from granian import Granian
 
 from .application import MereApp
 
+_CURRENT_APP: MereApp | None = None
+
+
+def _register_current_app(app: MereApp) -> None:
+    """Store ``app`` for retrieval by worker processes."""
+
+    global _CURRENT_APP
+    _CURRENT_APP = app
+
+
+def _clear_current_app() -> None:
+    """Clear any registered application instance."""
+
+    global _CURRENT_APP
+    _CURRENT_APP = None
+
+
+def _current_app_loader() -> MereApp:
+    """Return the application registered for the current process."""
+
+    if _CURRENT_APP is None:
+        raise RuntimeError("no Mere application registered for Granian")
+    return _CURRENT_APP
+
 
 class ServerConfig(msgspec.Struct, frozen=True):
     host: str = "0.0.0.0"
@@ -18,8 +42,9 @@ class ServerConfig(msgspec.Struct, frozen=True):
 
 def create_server(app: MereApp, config: ServerConfig | None = None) -> Granian:
     cfg = config or ServerConfig()
+    _register_current_app(app)
     return Granian(
-        app,
+        "mere.server:_current_app_loader",
         address=cfg.host,
         port=cfg.port,
         interface=cfg.interface,
@@ -30,4 +55,7 @@ def create_server(app: MereApp, config: ServerConfig | None = None) -> Granian:
 
 def run(app: MereApp, config: ServerConfig | None = None) -> None:
     server = create_server(app, config)
-    server.serve()
+    try:
+        server.serve(target_loader=_current_app_loader, wrap_loader=False)
+    finally:
+        _clear_current_app()

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -166,9 +166,7 @@ async def test_missing_route_returns_not_found(app: MereApp) -> None:
         response = await client.get("/missing", tenant="acme")
         assert response.status == Status.NOT_FOUND
         payload = json_decode(response.body)
-        assert payload == {
-            "error": {"status": 404, "reason": "Not Found", "detail": {"detail": "route_not_found"}}
-        }
+        assert payload == {"error": {"status": 404, "reason": "Not Found", "detail": {"detail": "route_not_found"}}}
 
 
 def test_security_middleware_ordering() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,10 +1,17 @@
 from __future__ import annotations
 
+import pytest
 from granian import Granian
 
 from mere.application import MereApp
 from mere.config import AppConfig
-from mere.server import ServerConfig, create_server, run
+from mere.server import (
+    ServerConfig,
+    _clear_current_app,
+    _current_app_loader,
+    create_server,
+    run,
+)
 
 
 def test_create_server_returns_granian() -> None:
@@ -12,6 +19,10 @@ def test_create_server_returns_granian() -> None:
     config = ServerConfig(host="127.0.0.1", port=9000, workers=2)
     server = create_server(app, config)
     assert isinstance(server, Granian)
+    try:
+        assert _current_app_loader() is app
+    finally:
+        _clear_current_app()
 
 
 def test_run_invokes_serve(monkeypatch) -> None:
@@ -19,8 +30,10 @@ def test_run_invokes_serve(monkeypatch) -> None:
     served = {"called": False}
 
     class DummyServer:
-        def serve(self) -> None:
+        def serve(self, target_loader=None, wrap_loader=True) -> None:
             served["called"] = True
+            served["loader"] = target_loader
+            served["wrap"] = wrap_loader
 
     def fake_create(app, config=None):
         return DummyServer()
@@ -28,3 +41,11 @@ def test_run_invokes_serve(monkeypatch) -> None:
     monkeypatch.setattr("mere.server.create_server", fake_create)
     run(app)
     assert served["called"] is True
+    assert served["loader"] is _current_app_loader
+    assert served["wrap"] is False
+
+
+def test_current_app_loader_without_registration() -> None:
+    _clear_current_app()
+    with pytest.raises(RuntimeError):
+        _current_app_loader()


### PR DESCRIPTION
## Summary
- ensure the Granian server helper registers the current Mere app and provides a stable loader for worker processes
- adjust server tests to assert the loader wiring and cover the no-registration error case
- tidy the not-found payload assertion in the application tests

## Testing
- uv run ruff format
- uv run ruff check
- uv run ty check
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68da71b22218832e9f6abf4ed0731d1e