### PR TITLE
Fix documentation base URLs for GitHub Pages

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Mere
 site_description: Async multi-tenant web framework
-site_url: https://github.com/alexogeny/mere
+site_url: https://alexogeny.github.io/mere/
 repo_url: https://github.com/alexogeny/mere
-repo_name: alexogeny/mere
+repo_name: mere
 
 nav:
   - Home: index.md


### PR DESCRIPTION
## Summary
- update the MkDocs configuration to use the GitHub Pages URL and correct repository name so navigation links resolve under `/mere`

## Testing
- uv run mkdocs build
- uv run ruff format
- uv run ruff check
- uv run ty check
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e340b92a84832ea67bea60ee33d40a