### PR TITLE
Add logging redaction controls to observability

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -26,6 +26,26 @@ The observability hooks expose async context managers for span creation, structu
 emitting metrics. The default implementation writes JSON events to stdout, but you can inject custom
 providers to integrate with OpenTelemetry, Honeycomb, or any other tracing system.
 
+### Controlling sensitive fields
+
+By default Mere redacts request paths and exception messages from structured logs. Override the
+behaviour by configuring `LoggingRedactionConfig` on the observability settings:
+
+```python
+from mere.observability import LoggingRedactionConfig, ObservabilityConfig
+
+config = ObservabilityConfig(
+    logging=LoggingRedactionConfig(
+        request_path="hash",  # "redact", "hash", or "raw"
+        exception_message="raw",
+        hash_salt="deploy-secret",  # optional salt to stabilise hashes
+    )
+)
+```
+
+`hash` mode keeps correlation while avoiding raw values, and `raw` opt-in restores the previous
+behaviour.
+
 ## Audit trails
 
 Audit trails capture sensitive operations in admin and tenant scopes. Use `AuditTrail` to wrap critical

--- a/src/mere/__init__.py
+++ b/src/mere/__init__.py
@@ -143,6 +143,7 @@ from .models import (
 )
 from .observability import (
     ChatOpsObservabilityConfig,
+    LoggingRedactionConfig,
     Observability,
     ObservabilityConfig,
     RequestObservabilityConfig,
@@ -265,6 +266,7 @@ __all__ = [
     "IssuedMfaCode",
     "IssuedSessionToken",
     "JSONResponse",
+    "LoggingRedactionConfig",
     "LoginStep",
     "Mere",
     "MereApp",


### PR DESCRIPTION
## Summary
- add a logging redaction configuration to observability so request paths and exception messages can be redacted or hashed before logging
- expose the configuration through the public API and document how to tune it
- extend observability tests to cover redaction modes and validation while keeping tracing behaviour intact

## Testing
- uv run ruff format
- uv run ruff check
- uv run ty check
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e35808b5e4832e9f4e3416d9fb436a