### PR TITLE
Harden observability defaults

### DIFF
--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -26,25 +26,55 @@ The observability hooks expose async context managers for span creation, structu
 emitting metrics. The default implementation writes JSON events to stdout, but you can inject custom
 providers to integrate with OpenTelemetry, Honeycomb, or any other tracing system.
 
-### Controlling sensitive fields
+### Opting in to external sinks
 
-By default Mere redacts request paths and exception messages from structured logs. Override the
-behaviour by configuring `LoggingRedactionConfig` on the observability settings:
+OpenTelemetry, Sentry, and Datadog integrations are disabled by default. Enable only the sinks you
+need to avoid leaking tenant identifiers accidentally:
 
 ```python
-from mere.observability import LoggingRedactionConfig, ObservabilityConfig
+from mere.observability import ObservabilityConfig
+
+config = ObservabilityConfig(
+    opentelemetry_enabled=True,
+    sentry_enabled=True,
+    datadog_enabled=True,
+)
+```
+
+These switches honour the `MERE_OBSERVABILITY_OPENTELEMETRY_ENABLED`,
+`MERE_OBSERVABILITY_SENTRY_ENABLED`, and `MERE_OBSERVABILITY_DATADOG_ENABLED` environment variables,
+so you can flip them per deployment without touching code.
+
+### Controlling sensitive fields
+
+By default Mere redacts request paths, exception messages, and tenant identifiers from structured
+logs and telemetry metadata. Override the behaviour by configuring `LoggingRedactionConfig` and
+`TenantRedactionConfig` on the observability settings:
+
+```python
+from mere.observability import (
+    LoggingRedactionConfig,
+    ObservabilityConfig,
+    TenantRedactionConfig,
+)
 
 config = ObservabilityConfig(
     logging=LoggingRedactionConfig(
         request_path="hash",  # "redact", "hash", or "raw"
         exception_message="raw",
         hash_salt="deploy-secret",  # optional salt to stabilise hashes
-    )
+    ),
+    tenant=TenantRedactionConfig(
+        log_fields="hash",
+        sentry_tags="redact",
+        datadog_tags="hash",
+    ),
 )
 ```
 
 `hash` mode keeps correlation while avoiding raw values, and `raw` opt-in restores the previous
-behaviour.
+behaviour for trusted sinks. Tenant masking applies to request logs, Sentry tags (including
+breadcrumbs), and Datadog tags.
 
 ## Audit trails
 

--- a/src/mere/__init__.py
+++ b/src/mere/__init__.py
@@ -149,6 +149,7 @@ from .observability import (
     Observability,
     ObservabilityConfig,
     RequestObservabilityConfig,
+    TenantRedactionConfig,
 )
 from .orm import (
     ORM,
@@ -322,6 +323,7 @@ __all__ = [
     "TenantContext",
     "TenantFederatedUser",
     "TenantOidcProvider",
+    "TenantRedactionConfig",
     "TenantResolver",
     "TenantSamlProvider",
     "TenantScope",


### PR DESCRIPTION
## Summary
- disable Datadog, Sentry, and OpenTelemetry by default and allow environment flags to re-enable them
- add tenant redaction controls across logs, Sentry metadata, and Datadog tags with hashing support
- refresh docs and tests to cover the opt-in workflow and masked tenant identifiers

## Testing
- uv run ruff format
- uv run ruff check
- uv run ty check
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e37296da9c832ebabf3726d63a5878