### PR TITLE
Enforce TLS configuration for server startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,14 @@ uv run example.py
 ```
 
 The script starts a Granian server with the bootstrap bundle already wired in. Override `MERE_SITE`,
-`MERE_DOMAIN`, `MERE_ALLOWED_TENANTS`, `MERE_HOST`, or `MERE_PORT` to tailor the tenancy hostnames and bind
-address. Provide a `DATABASE_URL` when you want the bootstrap tables to persist in PostgreSQL; otherwise the
-demo operates purely in memory.
+`MERE_DOMAIN`, `MERE_ALLOWED_TENANTS`, `MERE_HOST`, `MERE_PORT`, or `MERE_PROFILE` to tailor the tenancy
+hostnames, bind address, and runtime profile. Provide a `DATABASE_URL` when you want the bootstrap tables to
+persist in PostgreSQL; otherwise the demo operates purely in memory.
+
+Production profiles require TLS assets before the server will boot. Point `MERE_TLS_CERT`, `MERE_TLS_KEY`,
+and optionally `MERE_TLS_CA` at PEM-encoded files and set `MERE_TLS_CLIENT_VERIFY=1` when clients must present
+certificates. Development defaults skip TLS so the demo can run without generating certificates, but the
+server still listens on port 8443 by default to match production expectations.
 
 * **Diagnostics:** `/__mere/ping`, OpenAPI JSON, and a generated TypeScript client that all resolve for
   every tenant host (`*.site.domain`), including the admin control plane (`admin.site.domain`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,29 @@ uv run granian --interface rsgi --workers 1 mere.server:create_app
 The server will resolve requests for `https://acme.demo.local.test` and `https://beta.demo.local.test`
 by mapping each hostname to the corresponding tenant context.
 
+### TLS defaults
+
+`ServerConfig` now models TLS assets explicitly. In production profiles (`profile="production"`, the
+default) the server refuses to boot unless both `certificate_path` and `private_key_path` point to
+PEM-encoded files. Provide a certificate authority bundle through `ca_path` when terminating mutual TLS
+(`client_auth_required=True`). Development-oriented profiles (`development`, `dev`, `local`, or `test`)
+skip the requirement so you can iterate without generating certificates; when PEM files are present they
+are still wired into Granian so HTTPS works end-to-end.
+
+```python
+from pathlib import Path
+
+from mere.server import ServerConfig
+
+config = ServerConfig(
+    certificate_path=Path("/etc/mere/tls/server.crt"),
+    private_key_path=Path("/etc/mere/tls/server.key"),
+    ca_path=Path("/etc/mere/tls/clients.pem"),
+    profile="production",
+    client_auth_required=True,
+)
+```
+
 ## Quality checks
 
 Before committing changes, run the built-in quality command:

--- a/docs/ops/security.md
+++ b/docs/ops/security.md
@@ -14,3 +14,12 @@ multi-tenant flows. To keep production environments safe:
   values mentioned above are present.)
 
 Follow these practices before merging features or publishing the documentation site.
+
+## TLS enforcement
+
+Granian refuses to start without TLS material when `ServerConfig.profile` is not one of the development
+profiles (`development`, `dev`, `local`, or `test`). Provision PEM-encoded certificates and keys through the
+`certificate_path` and `private_key_path` fields (or the corresponding `MERE_TLS_CERT`/`MERE_TLS_KEY`
+environment variables). Enable mutual TLS by setting `client_auth_required=True` (or
+`MERE_TLS_CLIENT_VERIFY=1`) and providing a certificate authority bundle via `ca_path`/`MERE_TLS_CA`.
+Missing assets trigger a startup failure so misconfigured production nodes cannot serve plaintext traffic.

--- a/src/mere/server.py
+++ b/src/mere/server.py
@@ -2,12 +2,64 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from typing import Any, Mapping
+
 import msgspec
 from granian import Granian
 
 from .application import MereApp
 
 _CURRENT_APP: MereApp | None = None
+
+_DEV_PROFILES: frozenset[str] = frozenset({"development", "dev", "local", "test"})
+
+
+def _normalize_path(path: str | Path | None) -> Path | None:
+    """Coerce ``path`` into :class:`~pathlib.Path` instances when provided."""
+
+    if path is None:
+        return None
+    return path if isinstance(path, Path) else Path(path)
+
+
+def _path_state(path: str | Path | None) -> tuple[Path | None, bool]:
+    """Return a tuple of the normalized path and whether it exists."""
+
+    resolved = _normalize_path(path)
+    if resolved is None:
+        return None, False
+    return resolved, resolved.exists()
+
+
+def _require_paths(paths: Mapping[str, tuple[Path | None, bool]], *, profile: str) -> None:
+    """Ensure TLS assets exist when running outside development profiles."""
+
+    if profile.lower() in _DEV_PROFILES:
+        return
+
+    missing: list[str] = []
+    for label, (path, exists) in paths.items():
+        if path is None:
+            missing.append(label)
+        elif not exists:
+            missing.append(f"{label} ({path})")
+    if missing:
+        formatted = ", ".join(sorted(missing))
+        raise RuntimeError(f"TLS assets required for {profile!r} profile: missing {formatted}")
+
+
+def _ensure_client_auth(ca_bundle: tuple[Path | None, bool], required: bool) -> Path | None:
+    """Validate client-auth requirements before configuring Granian."""
+
+    path, exists = ca_bundle
+    if not required:
+        return path if exists else None
+    if path is None:
+        raise RuntimeError("Client certificate verification requested without a CA bundle")
+    if not exists:
+        raise RuntimeError(f"Client CA bundle not found at {path}")
+    return path
 
 
 def _register_current_app(app: MereApp) -> None:
@@ -34,23 +86,61 @@ def _current_app_loader() -> MereApp:
 
 class ServerConfig(msgspec.Struct, frozen=True):
     host: str = "0.0.0.0"
-    port: int = 8000
+    port: int = 8443
     interface: str = "asgi"
     loop: str = "rloop"
     workers: int = 1
+    certificate_path: str | Path | None = Path("config/tls/server.crt")
+    private_key_path: str | Path | None = Path("config/tls/server.key")
+    ca_path: str | Path | None = Path("config/tls/ca.crt")
+    client_auth_required: bool = False
+    profile: str = "production"
+
+
+def _granian_kwargs(cfg: ServerConfig) -> Mapping[str, Any]:
+    certificate = _path_state(cfg.certificate_path)
+    key = _path_state(cfg.private_key_path)
+    ca_bundle = _path_state(cfg.ca_path)
+
+    paths: dict[str, tuple[Path | None, bool]] = {
+        "certificate_path": certificate,
+        "private_key_path": key,
+    }
+    _require_paths(paths, profile=cfg.profile)
+
+    resolved_ca = _ensure_client_auth(ca_bundle, cfg.client_auth_required)
+
+    kwargs: dict[str, Any] = {
+        "address": cfg.host,
+        "port": cfg.port,
+        "interface": cfg.interface,
+        "loop": cfg.loop,
+        "workers": cfg.workers,
+    }
+    cert_path, cert_exists = certificate
+    key_path, key_exists = key
+    ca_path, ca_exists = ca_bundle
+    if cert_exists and key_exists:
+        kwargs["ssl_cert"] = cert_path
+        kwargs["ssl_key"] = key_path
+    if resolved_ca is not None:
+        kwargs["ssl_ca"] = resolved_ca
+    if cfg.client_auth_required:
+        kwargs["ssl_client_verify"] = True
+    elif ca_exists and ca_path is not None:
+        kwargs["ssl_ca"] = ca_path
+    return kwargs
 
 
 def create_server(app: MereApp, config: ServerConfig | None = None) -> Granian:
     cfg = config or ServerConfig()
     _register_current_app(app)
-    return Granian(
-        "mere.server:_current_app_loader",
-        address=cfg.host,
-        port=cfg.port,
-        interface=cfg.interface,
-        loop=cfg.loop,
-        workers=cfg.workers,
-    )
+    try:
+        kwargs = _granian_kwargs(cfg)
+        return Granian("mere.server:_current_app_loader", **kwargs)
+    except Exception:
+        _clear_current_app()
+        raise
 
 
 def run(app: MereApp, config: ServerConfig | None = None) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import pytest
-from granian import Granian
 
 from mere.application import MereApp
 from mere.config import AppConfig
@@ -14,11 +13,45 @@ from mere.server import (
 )
 
 
-def test_create_server_returns_granian() -> None:
+def _granian_spy(monkeypatch):
+    calls: list[dict[str, object]] = []
+
+    class DummyGranian:
+        def __init__(self, target: str, **kwargs):
+            calls.append({"target": target, "kwargs": kwargs})
+
+    monkeypatch.setattr("mere.server.Granian", DummyGranian)
+    return calls, DummyGranian
+
+
+def test_create_server_configures_tls(monkeypatch, tmp_path) -> None:
     app = MereApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
-    config = ServerConfig(host="127.0.0.1", port=9000, workers=2)
+    certificate = tmp_path / "server.crt"
+    key = tmp_path / "server.key"
+    ca = tmp_path / "ca.crt"
+    for path in (certificate, key, ca):
+        path.write_text("sample", encoding="utf-8")
+
+    calls, DummyGranian = _granian_spy(monkeypatch)
+
+    config = ServerConfig(
+        host="127.0.0.1",
+        port=9443,
+        workers=2,
+        certificate_path=certificate,
+        private_key_path=key,
+        ca_path=ca,
+        client_auth_required=True,
+        profile="production",
+    )
     server = create_server(app, config)
-    assert isinstance(server, Granian)
+    assert isinstance(server, DummyGranian)
+    assert calls and calls[0]["target"] == "mere.server:_current_app_loader"
+    kwargs = calls[0]["kwargs"]
+    assert kwargs["ssl_cert"] == certificate
+    assert kwargs["ssl_key"] == key
+    assert kwargs["ssl_ca"] == ca
+    assert kwargs["ssl_client_verify"] is True
     try:
         assert _current_app_loader() is app
     finally:
@@ -49,3 +82,97 @@ def test_current_app_loader_without_registration() -> None:
     _clear_current_app()
     with pytest.raises(RuntimeError):
         _current_app_loader()
+
+
+def test_create_server_rejects_missing_tls(tmp_path) -> None:
+    app = MereApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+    config = ServerConfig(
+        profile="production",
+        certificate_path=tmp_path / "missing.crt",
+        private_key_path=None,
+    )
+    with pytest.raises(RuntimeError, match="TLS assets required"):
+        create_server(app, config)
+
+
+def test_create_server_requires_client_ca_when_verification_enabled(tmp_path) -> None:
+    app = MereApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+    certificate = tmp_path / "server.crt"
+    key = tmp_path / "server.key"
+    certificate.write_text("cert", encoding="utf-8")
+    key.write_text("key", encoding="utf-8")
+
+    config = ServerConfig(
+        profile="production",
+        certificate_path=certificate,
+        private_key_path=key,
+        client_auth_required=True,
+        ca_path=None,
+    )
+    with pytest.raises(RuntimeError, match="Client certificate verification"):
+        create_server(app, config)
+
+
+def test_create_server_rejects_missing_client_ca_file(tmp_path) -> None:
+    app = MereApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+    certificate = tmp_path / "server.crt"
+    key = tmp_path / "server.key"
+    ca = tmp_path / "clients.crt"
+    certificate.write_text("cert", encoding="utf-8")
+    key.write_text("key", encoding="utf-8")
+
+    config = ServerConfig(
+        profile="production",
+        certificate_path=certificate,
+        private_key_path=key,
+        client_auth_required=True,
+        ca_path=ca,
+    )
+    with pytest.raises(RuntimeError, match="Client CA bundle not found"):
+        create_server(app, config)
+
+
+def test_create_server_wires_ca_without_client_auth(monkeypatch, tmp_path) -> None:
+    app = MereApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+    calls, DummyGranian = _granian_spy(monkeypatch)
+    certificate = tmp_path / "server.crt"
+    key = tmp_path / "server.key"
+    ca = tmp_path / "clients.crt"
+    for path in (certificate, key, ca):
+        path.write_text("data", encoding="utf-8")
+
+    config = ServerConfig(
+        profile="production",
+        certificate_path=certificate,
+        private_key_path=key,
+        ca_path=ca,
+        client_auth_required=False,
+    )
+    try:
+        server = create_server(app, config)
+        assert isinstance(server, DummyGranian)
+        kwargs = calls[0]["kwargs"]
+        assert kwargs.get("ssl_ca") == ca
+        assert "ssl_client_verify" not in kwargs
+    finally:
+        _clear_current_app()
+
+
+def test_create_server_allows_plaintext_for_development(monkeypatch) -> None:
+    app = MereApp(AppConfig(site="demo", domain="example.com", allowed_tenants=("acme", "beta")))
+    calls, DummyGranian = _granian_spy(monkeypatch)
+    config = ServerConfig(
+        profile="development",
+        certificate_path=None,
+        private_key_path=None,
+        ca_path=None,
+    )
+    try:
+        server = create_server(app, config)
+        assert isinstance(server, DummyGranian)
+        kwargs = calls[0]["kwargs"]
+        assert "ssl_cert" not in kwargs
+        assert "ssl_key" not in kwargs
+        assert "ssl_ca" not in kwargs
+    finally:
+        _clear_current_app()


### PR DESCRIPTION
## Summary
- extend the Granian server config to carry TLS certificate, key, CA paths and client-auth flags while gating startup by profile
- wire TLS inputs into the server factory, update the example bootstrapper, and document the new environment knobs
- add regression tests covering HTTPS configuration success paths and failure scenarios when TLS assets are missing

## Testing
- uv run ruff format
- uv run ruff check
- uv run ty check
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e37e333fc4832eab21bba94859bd80