### PR TITLE
Broaden compliance regression coverage across frameworks

### DIFF
--- a/tests/test_compliance_gdpr.py
+++ b/tests/test_compliance_gdpr.py
@@ -1,0 +1,131 @@
+"""GDPR Article 5 and Article 32 regression tests for privacy controls."""
+
+from __future__ import annotations
+
+import pytest
+
+from mere.observability import (
+    LoggingRedactionConfig,
+    Observability,
+    ObservabilityConfig,
+    TenantRedactionConfig,
+)
+from mere.tenancy import TenantResolutionError, TenantResolver, TenantScope
+
+
+def test_gdpr_request_logging_is_redacted() -> None:
+    """Article 5(1)(c) data minimisation: redact identifiers from logs."""
+
+    config = ObservabilityConfig(
+        logging=LoggingRedactionConfig(request_path="redact", exception_message="hash"),
+        tenant=TenantRedactionConfig(log_fields="redact"),
+    )
+    observability = Observability(config)
+
+    payload = {"http.path": "/users/12345", "tenant": "acme", "error_message": "User email leaked"}
+    observability._sanitize_log_payload(payload)
+
+    assert payload["http.path"] == "[redacted]"
+    assert payload["tenant"] == "[redacted]"
+    assert payload["error_message"].startswith("[hash:")
+
+
+def test_gdpr_rejects_ambiguous_tenant_hosts() -> None:
+    """Article 32 requires strict isolation; nested tenant hosts are rejected."""
+
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme", "beta"))
+    with pytest.raises(TenantResolutionError):
+        resolver.resolve("nested.acme.demo.example.com")
+
+
+def test_gdpr_rejects_invalid_port_specifications() -> None:
+    """Article 32(1)(b) enforces rejection of malformed network endpoints."""
+
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme",))
+    with pytest.raises(TenantResolutionError):
+        resolver.resolve("acme.demo.example.com:abc")
+
+
+def test_gdpr_rejects_hosts_with_whitespace() -> None:
+    """Article 32(1)(d) blocks host headers with surrounding whitespace."""
+
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme",))
+    with pytest.raises(TenantResolutionError):
+        resolver.resolve(" acme.demo.example.com ")
+
+
+def test_gdpr_public_host_maps_to_marketing_scope() -> None:
+    """Article 25 privacy by design keeps marketing hosts in a public scope."""
+
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme", "beta"))
+    context = resolver.resolve("demo.example.com")
+    assert context.scope is TenantScope.PUBLIC
+    assert context.tenant == "public"
+
+
+def test_gdpr_admin_host_maps_to_privileged_scope() -> None:
+    """Article 28(3)(h) ensures processor administration occurs on dedicated hosts."""
+
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme", "beta"))
+    context = resolver.resolve("admin.demo.example.com")
+    assert context.scope is TenantScope.ADMIN
+    assert context.tenant == "admin"
+
+
+def test_gdpr_resolver_supports_multiple_tenants_without_overlap() -> None:
+    """Article 30 records of processing require deterministic tenant routing."""
+
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme", "beta"))
+    acme = resolver.context_for("acme")
+    beta = resolver.context_for("beta")
+
+    assert acme.host == "acme.demo.example.com"
+    assert beta.host == "beta.demo.example.com"
+    assert acme.key() != beta.key()
+
+
+def test_gdpr_hash_strategy_is_stable_for_log_payloads() -> None:
+    """Article 5(1)(c) requires consistent hashing for audit comparisons."""
+
+    config = ObservabilityConfig(
+        logging=LoggingRedactionConfig(request_path="hash", exception_message="hash", hash_salt="pepper"),
+        tenant=TenantRedactionConfig(log_fields="hash"),
+    )
+    observability = Observability(config)
+    payload_a = {"http.path": "/users/42", "tenant": "acme"}
+    payload_b = {"http.path": "/users/42", "tenant": "acme"}
+
+    observability._sanitize_log_payload(payload_a)
+    observability._sanitize_log_payload(payload_b)
+    assert payload_a == payload_b
+
+
+def test_gdpr_log_hashing_masks_tenant_metadata() -> None:
+    """Article 32(2) limits tenant identifiers in operational logs."""
+
+    config = ObservabilityConfig(tenant=TenantRedactionConfig(log_fields="hash"))
+    observability = Observability(config)
+    payload = {"tenant": "acme", "http.tenant": "beta", "site": "demo", "http.site": "demo.example.com"}
+
+    observability._sanitize_log_payload(payload)
+    for value in payload.values():
+        assert isinstance(value, str) and value.startswith("[hash:")
+
+
+def test_gdpr_datadog_tags_can_be_fully_redacted() -> None:
+    """Article 5(1)(f) enforces confidentiality for exported monitoring tags."""
+
+    config = ObservabilityConfig(tenant=TenantRedactionConfig(datadog_tags="redact"))
+    observability = Observability(config)
+
+    tags = observability._sanitize_datadog_tags(("tenant:acme", "http.site:demo.example.com"))
+    assert tags[0] == "tenant:[redacted]"
+    assert tags[1] == "http.site:[redacted]"
+
+
+def test_gdpr_unknown_tenant_is_rejected() -> None:
+    """Article 5(1)(d) demands accuracy checks for declared tenant identifiers."""
+
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme",))
+    with pytest.raises(TenantResolutionError):
+        resolver.context_for("beta")

--- a/tests/test_compliance_hipaa.py
+++ b/tests/test_compliance_hipaa.py
@@ -1,0 +1,177 @@
+"""HIPAA Security Rule regression tests for the Mere authentication and auditing stack."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import msgspec
+import pytest
+
+from mere.audit import UPDATE, AuditActor, AuditTrail, audit_context
+from mere.authentication import AuthenticationError, AuthenticationRateLimiter
+from mere.database import Database, DatabaseConfig, PoolConfig
+from mere.models import TenantAuditLogEntry, TenantUser
+from mere.orm import default_registry
+from mere.tenancy import TenantResolver
+from tests.support import FakeConnection, FakePool
+
+
+@pytest.mark.asyncio
+async def test_hipaa_rate_limiter_enforces_account_lockouts() -> None:
+    """164.308(a)(5)(ii)(C) requires automatic lockouts after repeated failures."""
+
+    rate_limiter = AuthenticationRateLimiter(max_attempts=2, lockout_period=dt.timedelta(minutes=15))
+    now = dt.datetime(2024, 5, 1, tzinfo=dt.timezone.utc)
+
+    await rate_limiter.enforce(["tenant:acme:user"], now)
+    await rate_limiter.record_failure(["tenant:acme:user"], now)
+    await rate_limiter.record_failure(["tenant:acme:user"], now + dt.timedelta(seconds=1))
+
+    with pytest.raises(AuthenticationError) as excinfo:
+        await rate_limiter.enforce(["tenant:acme:user"], now + dt.timedelta(seconds=2))
+    assert str(excinfo.value) == "account_locked"
+
+
+@pytest.mark.asyncio
+async def test_hipaa_rate_limiter_resets_after_lockout_window() -> None:
+    """164.308(a)(5) requires lockouts to expire after the defined interval."""
+
+    rate_limiter = AuthenticationRateLimiter(max_attempts=2, lockout_period=dt.timedelta(seconds=2))
+    now = dt.datetime(2024, 5, 1, 12, 0, tzinfo=dt.timezone.utc)
+    key = ["tenant:acme:clinician"]
+
+    await rate_limiter.record_failure(key, now)
+    await rate_limiter.record_failure(key, now + dt.timedelta(milliseconds=500))
+
+    with pytest.raises(AuthenticationError):
+        await rate_limiter.enforce(key, now + dt.timedelta(seconds=1))
+
+    # After the lockout window has passed the clinician may attempt to sign in again.
+    await rate_limiter.enforce(key, now + dt.timedelta(seconds=3))
+
+
+@pytest.mark.asyncio
+async def test_hipaa_rate_limiter_applies_progressive_cooldown() -> None:
+    """164.308(a)(5)(ii)(B) mandates throttling before full lockout."""
+
+    rate_limiter = AuthenticationRateLimiter(
+        max_attempts=3,
+        base_cooldown=dt.timedelta(seconds=4),
+        max_cooldown=dt.timedelta(seconds=8),
+    )
+    now = dt.datetime(2024, 5, 1, 13, 0, tzinfo=dt.timezone.utc)
+    key = ["tenant:beta:clinician"]
+
+    await rate_limiter.enforce(key, now)
+    await rate_limiter.record_failure(key, now)
+
+    with pytest.raises(AuthenticationError) as excinfo:
+        await rate_limiter.enforce(key, now + dt.timedelta(seconds=2))
+    assert str(excinfo.value) == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_hipaa_rate_limiter_prunes_historic_identities() -> None:
+    """164.310(d)(2)(ii) expects stale authentication identifiers to be purged."""
+
+    rate_limiter = AuthenticationRateLimiter(max_attempts=1, max_entries=1)
+    now = dt.datetime(2024, 5, 1, 14, 0, tzinfo=dt.timezone.utc)
+
+    await rate_limiter.record_failure(["tenant:acme:patient"], now)
+    await rate_limiter.record_failure(["tenant:beta:patient"], now + dt.timedelta(seconds=1))
+
+    # The acme identity should have been pruned when the beta patient was recorded.
+    await rate_limiter.enforce(["tenant:acme:patient"], now + dt.timedelta(seconds=2))
+
+
+@pytest.mark.asyncio
+async def test_hipaa_rate_limiter_clears_state_after_success() -> None:
+    """164.308(a)(5)(ii)(B) resets throttling once a user successfully authenticates."""
+
+    rate_limiter = AuthenticationRateLimiter(max_attempts=1, lockout_period=dt.timedelta(minutes=5))
+    now = dt.datetime(2024, 5, 1, 15, 0, tzinfo=dt.timezone.utc)
+    key = ["tenant:acme:nurse"]
+
+    await rate_limiter.record_failure(key, now)
+    with pytest.raises(AuthenticationError):
+        await rate_limiter.enforce(key, now + dt.timedelta(seconds=1))
+
+    await rate_limiter.record_success(key)
+    await rate_limiter.enforce(key, now + dt.timedelta(seconds=2))
+
+
+@pytest.mark.asyncio
+async def test_hipaa_audit_metadata_redacts_protected_health_information() -> None:
+    """164.312(b) audit controls demand redaction of PHI snapshots."""
+
+    now = dt.datetime(2024, 5, 2, tzinfo=dt.timezone.utc)
+    connection = FakeConnection()
+    pool = FakePool(connection)
+    database = Database(DatabaseConfig(pool=PoolConfig(dsn="postgres://")), pool=pool)
+    trail = AuditTrail(database, registry=default_registry(), clock=lambda: now)
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme",))
+    tenant = resolver.context_for("acme")
+
+    actor = AuditActor(id="clinician-1", type="Clinician")
+    before = {"email": "old@example.com", "hashed_password": "legacy"}
+    user = TenantUser(email="patient@example.com", hashed_password="secret")
+    row = msgspec.to_builtins(user)
+
+    async with audit_context(tenant=tenant, actor=actor):
+        await trail.record_model_change(
+            info=default_registry().info_for(TenantUser),
+            action=UPDATE,
+            tenant=tenant,
+            data=row,
+            changes=row,
+            before=before,
+        )
+
+    _, _, params, _ = connection.calls[-1]
+    info = default_registry().info_for(TenantAuditLogEntry)
+    inserted = {field.name: value for field, value in zip(info.fields, params)}
+    assert inserted["metadata"]["before"]["email"] == "old@example.com"
+    assert "hashed_password" not in inserted["metadata"]["before"]
+
+
+@pytest.mark.asyncio
+async def test_hipaa_rate_limiter_drops_inactive_entries() -> None:
+    """164.308(a)(1)(ii)(D) prunes dormant login records after monitoring review."""
+
+    rate_limiter = AuthenticationRateLimiter(window=dt.timedelta(seconds=1))
+    now = dt.datetime(2024, 5, 1, 16, 0, tzinfo=dt.timezone.utc)
+    key = ["tenant:beta:physician"]
+
+    await rate_limiter.record_failure(key, now)
+    await rate_limiter.enforce(key, now + dt.timedelta(seconds=2))
+
+
+@pytest.mark.asyncio
+async def test_hipaa_audit_custom_events_include_tenant_context() -> None:
+    """164.312(b) requires tenant identifiers to accompany manual disclosures."""
+
+    now = dt.datetime(2024, 5, 3, tzinfo=dt.timezone.utc)
+    connection = FakeConnection()
+    pool = FakePool(connection)
+    database = Database(DatabaseConfig(pool=PoolConfig(dsn="postgres://")), pool=pool)
+    trail = AuditTrail(database, registry=default_registry(), clock=lambda: now)
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme", "beta"))
+    tenant = resolver.context_for("beta")
+    actor = AuditActor(id="hipaa-officer", type="AdminUser")
+
+    async with audit_context(tenant=tenant, actor=actor):
+        await trail.record_custom(
+            scope="tenant",
+            tenant=tenant,
+            action="export-phi",
+            entity_type="patient_record",
+            entity_id="record-123",  # unique disclosure identifier
+            changes={"fields": ["dob", "lab_results"]},
+        )
+
+    insert_calls = [call for call in connection.calls if call[0] == "execute" and call[1].startswith("INSERT")]
+    info = default_registry().info_for(TenantAuditLogEntry)
+    row = {field.name: value for field, value in zip(info.fields, insert_calls[0][2])}
+    assert row["entity_id"] == "record-123"
+    assert row["metadata"]["tenant"] == "beta"
+    assert row["changes"]["fields"] == ["dob", "lab_results"]

--- a/tests/test_compliance_iso27001.py
+++ b/tests/test_compliance_iso27001.py
@@ -1,0 +1,150 @@
+"""ISO/IEC 27001:2022 Annex A control coverage tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from mere.database import DatabaseCredentials, DatabaseError, SecretRef, SecretValue, TLSConfig
+from mere.observability import (
+    LoggingRedactionConfig,
+    Observability,
+    ObservabilityConfig,
+    TenantRedactionConfig,
+)
+from tests.support import StaticSecretResolver
+
+
+def test_iso27001_tls_config_resolves_secrets() -> None:
+    """Annex A.8.24 and A.10.1 require protecting cryptographic material."""
+
+    resolver = StaticSecretResolver(
+        {
+            ("vault", "ca-cert", None): "CA",  # trusted root
+            ("vault", "client-cert", None): "CLIENT",  # client certificate
+            ("vault", "client-key", None): "CLIENT_KEY",  # client key
+            ("vault", "client-key-pass", None): "KEYPASS",  # encrypted key password
+        }
+    )
+    tls = TLSConfig(
+        mode="verify-full",
+        ca_certificate=SecretValue(secret=SecretRef("vault", "ca-cert", None)),
+        client_certificate=SecretValue(secret=SecretRef("vault", "client-cert", None)),
+        client_key=SecretValue(secret=SecretRef("vault", "client-key", None)),
+        client_key_password=SecretValue(secret=SecretRef("vault", "client-key-pass", None)),
+        server_name="db.internal",
+        certificate_pins=("sha256/abcdef",),
+        minimum_version="TLSv1.2",
+        maximum_version="TLSv1.3",
+    )
+
+    options = tls.resolve(resolver)
+    assert options["sslmode"] == "verify-full"
+    assert options["sslrootcert"] == "CA"
+    assert options["sslcert"] == "CLIENT"
+    assert options["sslkey"] == "CLIENT_KEY"
+    assert options["sslpassword"] == "KEYPASS"
+    assert options["ssl_server_name"] == "db.internal"
+    assert options["ssl_cert_pins"] == ("sha256/abcdef",)
+    assert options["ssl_min_protocol_version"] == "TLSv1.2"
+    assert options["ssl_max_protocol_version"] == "TLSv1.3"
+
+
+def test_iso27001_datadog_tag_sanitization() -> None:
+    """Annex A.8.11/A.8.12 expect tenant metadata to be sanitised before export."""
+
+    config = ObservabilityConfig(tenant=TenantRedactionConfig(datadog_tags="hash"))
+    observability = Observability(config)
+
+    tags = observability._sanitize_datadog_tags(
+        (
+            "tenant:acme",
+            "chatops.site:demo",
+            "http.site:demo.example",
+            "service:mere",
+        )
+    )
+    assert tags[0].startswith("tenant:[hash:")
+    assert tags[1].startswith("chatops.site:[hash:")
+    assert tags[2].startswith("http.site:[hash:")
+    assert "service:mere" in tags
+
+
+def test_iso27001_secret_resolution_requires_controls() -> None:
+    """Annex A.5.30 mandates secret retrieval go through controlled resolvers."""
+
+    credential = SecretValue(secret=SecretRef("vault", "db-user", None))
+    with pytest.raises(DatabaseError) as excinfo:
+        credential.resolve(None, field="credentials.username")
+    assert "Secret resolver required" in str(excinfo.value)
+
+
+def test_iso27001_database_credentials_merge_sources() -> None:
+    """Annex A.9.2.1 requires least privilege credentials to be centralised."""
+
+    resolver = StaticSecretResolver({("vault", "db-user", None): "service"})
+    credentials = DatabaseCredentials(
+        username=SecretValue(secret=SecretRef("vault", "db-user", None)),
+        password=SecretValue(literal="inline-secret"),
+    )
+
+    resolved = credentials.resolve(resolver)
+    assert resolved == {"user": "service", "password": "inline-secret"}
+
+
+def test_iso27001_logging_hashes_sensitive_identifiers() -> None:
+    """Annex A.12.4.1 expects sensitive HTTP attributes to be anonymised."""
+
+    config = ObservabilityConfig(
+        logging=LoggingRedactionConfig(
+            request_path="hash",
+            exception_message="hash",
+            hash_salt="pepper",
+        ),
+    )
+    observability = Observability(config)
+    payload = {"http.path": "/patients/42", "error_message": "PHI leaked"}
+
+    observability._sanitize_log_payload(payload)
+    assert payload["http.path"].startswith("[hash:")
+    assert payload["error_message"].startswith("[hash:")
+
+
+def test_iso27001_datadog_respects_raw_strategy() -> None:
+    """Annex A.8.10 allows raw tenant tags only when explicitly approved."""
+
+    config = ObservabilityConfig(tenant=TenantRedactionConfig(datadog_tags="raw"))
+    observability = Observability(config)
+
+    tags = observability._sanitize_datadog_tags(("tenant:acme", "service:mere"))
+    assert tags == ("tenant:acme", "service:mere")
+
+
+def test_iso27001_tls_config_handles_optional_material() -> None:
+    """Annex A.10.1.1 allows disabling TLS fields only when controls documented."""
+
+    tls = TLSConfig(mode="")
+    assert tls.resolve(None) == {}
+
+
+def test_iso27001_tracestate_rejects_control_characters() -> None:
+    """Annex A.8.16 validates telemetry headers for integrity before export."""
+
+    assert Observability._sanitize_tracestate("tenant=acme\x00sig") is None
+    assert Observability._sanitize_tracestate(None) is None
+
+
+def test_iso27001_tracestate_trims_extraneous_whitespace() -> None:
+    """Annex A.8.16 strips whitespace to preserve canonical tracing metadata."""
+
+    assert Observability._sanitize_tracestate("  vendor=mere ") == "vendor=mere"
+
+
+def test_iso27001_sentry_tags_follow_tenant_strategy() -> None:
+    """Annex A.8.11 requires tenant identifiers in Sentry to be anonymised."""
+
+    config = ObservabilityConfig(tenant=TenantRedactionConfig(sentry_tags="hash"))
+    observability = Observability(config)
+    tags = observability._sanitize_sentry_tags({"tenant": "acme", "release": "1.2.3"})
+    assert tags is not None
+    assert tags["tenant"].startswith("[hash:")
+    assert tags["release"] == "1.2.3"

--- a/tests/test_compliance_soc2.py
+++ b/tests/test_compliance_soc2.py
@@ -1,0 +1,255 @@
+"""SOC 2 Trust Services Criteria regression tests for the Mere web framework."""
+
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import msgspec
+import pytest
+
+from mere.application import MereApp
+from mere.audit import INSERT, AuditActor, AuditTrail, audit_context
+from mere.database import Database, DatabaseConfig, PoolConfig
+from mere.models import AdminAuditLogEntry, TenantAuditLogEntry, TenantUser
+from mere.orm import default_registry
+from mere.server import (
+    ServerConfig,
+    _clear_current_app,
+    _current_app_loader,
+    _ensure_client_auth,
+    _granian_kwargs,
+    _register_current_app,
+    _require_paths,
+)
+from mere.tenancy import TenantResolver, TenantScope
+from tests.support import FakeConnection, FakePool
+
+
+@pytest.mark.asyncio
+async def test_soc2_audit_trail_redacts_sensitive_changes() -> None:
+    """SOC 2 CC7.2/CC7.4 require tamper-evident audit trails with sensitive fields redacted."""
+
+    now = dt.datetime(2024, 4, 1, tzinfo=dt.timezone.utc)
+    connection = FakeConnection()
+    pool = FakePool(connection)
+    database = Database(DatabaseConfig(pool=PoolConfig(dsn="postgres://")), pool=pool)
+    trail = AuditTrail(database, registry=default_registry(), clock=lambda: now)
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme", "beta"))
+    tenant = resolver.context_for("acme")
+
+    actor = AuditActor(id="admin-1", type="AdminUser")
+    user = TenantUser(email="user@example.com", hashed_password="super-secret")
+    row = msgspec.to_builtins(user)
+
+    async with audit_context(tenant=tenant, actor=actor):
+        await trail.record_model_change(
+            info=default_registry().info_for(TenantUser),
+            action=INSERT,
+            tenant=tenant,
+            data=row,
+            changes=row,
+        )
+
+    _, _, params, _ = connection.calls[-1]
+    info = default_registry().info_for(TenantAuditLogEntry)
+    inserted = {field.name: value for field, value in zip(info.fields, params)}
+    assert inserted["action"] == "insert"
+    assert inserted["metadata"]["tenant"] == "acme"
+    assert inserted["changes"]["email"] == "user@example.com"
+    assert "hashed_password" not in inserted["changes"]
+    assert inserted["created_at"] == now
+
+
+def test_soc2_tls_assets_required_outside_dev() -> None:
+    """SOC 2 CC6.7 mandates TLS assets before serving production traffic."""
+
+    paths = {
+        "certificate_path": (Path("config/tls/server.crt"), False),
+        "private_key_path": (Path("config/tls/server.key"), False),
+    }
+    with pytest.raises(RuntimeError) as excinfo:
+        _require_paths(paths, profile="production")
+    message = str(excinfo.value)
+    assert "TLS assets required" in message
+    assert "certificate_path" in message and "private_key_path" in message
+
+
+def test_soc2_dev_profile_defers_tls_asset_enforcement() -> None:
+    """SOC 2 CC6.7 allows relaxed TLS checks in isolated development profiles."""
+
+    paths = {
+        "certificate_path": (Path("config/tls/server.crt"), False),
+        "private_key_path": (Path("config/tls/server.key"), False),
+    }
+
+    # No exception should be raised when running in a recognised development profile.
+    _require_paths(paths, profile="development")
+
+
+def test_soc2_client_auth_requires_trusted_ca_bundle(tmp_path: Path) -> None:
+    """SOC 2 CC6.6 enforces client certificate validation with a trusted CA bundle."""
+
+    ca_path = tmp_path / "ca.pem"
+    ca_path.write_text("dummy")
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _ensure_client_auth((ca_path, False), required=True)
+    assert "Client CA bundle" in str(excinfo.value)
+
+    assert _ensure_client_auth((ca_path, True), required=True) == ca_path
+    assert _ensure_client_auth((ca_path, False), required=False) is None
+
+
+def test_soc2_granian_kwargs_configures_mutual_tls(tmp_path: Path) -> None:
+    """SOC 2 CC6.6/CC6.7 require mutual TLS enforcement in production."""
+
+    certificate_path = tmp_path / "server.crt"
+    certificate_path.write_text("cert")
+    key_path = tmp_path / "server.key"
+    key_path.write_text("key")
+    ca_path = tmp_path / "ca.pem"
+    ca_path.write_text("ca")
+
+    config = ServerConfig(
+        certificate_path=certificate_path,
+        private_key_path=key_path,
+        ca_path=ca_path,
+        client_auth_required=True,
+        profile="production",
+    )
+
+    kwargs = _granian_kwargs(config)
+    assert kwargs["ssl_cert"] == certificate_path
+    assert kwargs["ssl_key"] == key_path
+    assert kwargs["ssl_ca"] == ca_path
+    assert kwargs["ssl_client_verify"] is True
+
+
+def test_soc2_granian_kwargs_carries_optional_ca_bundle(tmp_path: Path) -> None:
+    """SOC 2 CC6.7 retains trusted roots even when client auth is optional."""
+
+    certificate_path = tmp_path / "server.crt"
+    certificate_path.write_text("cert")
+    key_path = tmp_path / "server.key"
+    key_path.write_text("key")
+    ca_path = tmp_path / "ca.pem"
+    ca_path.write_text("ca")
+
+    config = ServerConfig(
+        certificate_path=certificate_path,
+        private_key_path=key_path,
+        ca_path=ca_path,
+        client_auth_required=False,
+        profile="production",
+    )
+
+    kwargs = _granian_kwargs(config)
+    assert kwargs["ssl_cert"] == certificate_path
+    assert kwargs["ssl_key"] == key_path
+    assert kwargs["ssl_ca"] == ca_path
+    assert "ssl_client_verify" not in kwargs
+
+
+def test_soc2_current_app_registration_is_controlled() -> None:
+    """SOC 2 CC5.2 requires controlled promotion of the active application."""
+
+    _clear_current_app()
+    with pytest.raises(RuntimeError):
+        _current_app_loader()
+
+    app = MereApp()
+    try:
+        _register_current_app(app)
+        assert _current_app_loader() is app
+    finally:
+        _clear_current_app()
+
+
+@pytest.mark.asyncio
+async def test_soc2_admin_audit_entries_are_isolated() -> None:
+    """SOC 2 CC7.2 demands privileged actions be captured in the admin audit log."""
+
+    now = dt.datetime(2024, 4, 2, tzinfo=dt.timezone.utc)
+    connection = FakeConnection()
+    pool = FakePool(connection)
+    database = Database(DatabaseConfig(pool=PoolConfig(dsn="postgres://")), pool=pool)
+    trail = AuditTrail(database, registry=default_registry(), clock=lambda: now)
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme", "beta"))
+    admin = resolver.context_for("admin", scope=TenantScope.ADMIN)
+    actor = AuditActor(id="security", type="AdminUser")
+
+    async with audit_context(tenant=admin, actor=actor):
+        await trail.record_custom(
+            scope="admin",
+            tenant=None,
+            action="rotate-keys",
+            entity_type="tls_config",
+            metadata={"reason": "scheduled"},
+        )
+
+    # First call sets the admin search path, second call inserts the audit row.
+    assert '"admin"' in connection.calls[0][1]
+    assert '"admin"."admin_audit_log"' in connection.calls[1][1]
+
+    info = default_registry().info_for(AdminAuditLogEntry)
+    inserted = {field.name: value for field, value in zip(info.fields, connection.calls[1][2])}
+    assert inserted["action"] == "rotate-keys"
+    assert inserted["actor_id"] == "security"
+    assert inserted["metadata"]["reason"] == "scheduled"
+    assert inserted["metadata"]["tenant"] == "admin"
+
+
+@pytest.mark.asyncio
+async def test_soc2_tenant_audit_trail_maintains_schema_isolation() -> None:
+    """SOC 2 CC6.6 requires tenant actions to be logged in tenant-scoped schemas."""
+
+    now = dt.datetime(2024, 4, 3, tzinfo=dt.timezone.utc)
+    connection = FakeConnection()
+    pool = FakePool(connection)
+    database = Database(DatabaseConfig(pool=PoolConfig(dsn="postgres://")), pool=pool)
+    trail = AuditTrail(database, registry=default_registry(), clock=lambda: now)
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme", "beta"))
+    actor = AuditActor(id="auditor", type="SupportAgent")
+
+    for tenant in (resolver.context_for("acme"), resolver.context_for("beta")):
+        user = TenantUser(email=f"user@{tenant.tenant}.example.com", hashed_password="secret")
+        row = msgspec.to_builtins(user)
+        async with audit_context(tenant=tenant, actor=actor):
+            await trail.record_model_change(
+                info=default_registry().info_for(TenantUser),
+                action=INSERT,
+                tenant=tenant,
+                data=row,
+                changes=row,
+            )
+
+    insert_calls = [call for call in connection.calls if call[0] == "execute" and call[1].startswith("INSERT")]
+    assert len(insert_calls) == 2
+    info = default_registry().info_for(TenantAuditLogEntry)
+
+    first_row = {field.name: value for field, value in zip(info.fields, insert_calls[0][2])}
+    second_row = {field.name: value for field, value in zip(info.fields, insert_calls[1][2])}
+
+    assert '"tenant_acme"' in insert_calls[0][1]
+    assert '"tenant_beta"' in insert_calls[1][1]
+    assert first_row["metadata"]["tenant"] == "acme"
+    assert second_row["metadata"]["tenant"] == "beta"
+    assert first_row["changes"]["email"].endswith("@acme.example.com")
+    assert second_row["changes"]["email"].endswith("@beta.example.com")
+
+
+def test_soc2_database_schema_overrides_preserve_isolation() -> None:
+    """SOC 2 CC6.1 keeps tenant schemas isolated with explicit overrides."""
+
+    resolver = TenantResolver(site="demo", domain="example.com", allowed_tenants=("acme", "beta"))
+    config = DatabaseConfig(
+        tenant_schema_template="tenant_{tenant}",
+        tenant_schema_overrides={"beta": "tenant_beta_custom"},
+    )
+
+    acme_context = resolver.context_for("acme")
+    beta_context = resolver.context_for("beta")
+
+    assert config.schema_for_tenant(acme_context) == "tenant_acme"
+    assert config.schema_for_tenant(beta_context) == "tenant_beta_custom"


### PR DESCRIPTION
## Summary
- expand SOC 2 suite with admin logging, tenant isolation, TLS enforcement checks, and mutual TLS/app registration controls
- grow ISO/IEC 27001 coverage for secret resolution and observability redaction strategies, including tracestate and Sentry tag handling
- broaden GDPR and HIPAA tests across tenancy routing, log hashing, authentication controls, and stricter host hygiene/lockout recovery

## Testing
- uv run ruff format
- uv run ruff check
- uv run ty check
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3b1b0b5ac832eaf43eaa4af0ad0d5